### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,6 @@
 name: deploy
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/cibt0943/chimera/security/code-scanning/1](https://github.com/cibt0943/chimera/security/code-scanning/1)

To fix this problem, we should explicitly specify a `permissions:` block at the top level of the workflow or on each job requiring it. The safest, simplest fix is to add the block at the workflow root (just after the `name:`), assigning `contents: read` only, which is the minimum permission needed for most workflows and often sufficient for deployment jobs where the GITHUB_TOKEN is not used to push tags, releases, or manipulate issues. This change does not alter the workflow's existing functionality and establishes a clear security posture. Edit `.github/workflows/deploy.yml` by inserting the following:

```yaml
permissions:
  contents: read
```

after the `name:` block (i.e., between lines 1 and 2 in the provided snippet).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
